### PR TITLE
Adds Anchor feature and derivations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ travis-ci = { repository = "programble/fix" }
 i128 = ["typenum/i128"]
 
 [dependencies]
-borsh = { version = "1.3.1", features = ["derive"] }
+anchor-lang = "0.29.0"
+borsh = { version = "1.3.1", features = ["derive", "std"] }
 num-traits = "0.2.17"
 typenum = "1.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ i128 = ["typenum/i128"]
 anchor-lang = "0.29.0"
 borsh = { version = "1.3.1", features = ["derive", "std"] }
 num-traits = "0.2.17"
-typenum = "1.17.0"
+typenum = { version = "1.17.0", features = ["i128"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["data-structures"]
 travis-ci = { repository = "programble/fix" }
 
 [features]
-borsh = [ "dep:borsh" ]
+anchor = ["dep:anchor-lang"]
 
 [dependencies]
-borsh = { version = "1.3.1", features = ["derive", "std"], optional = true }
+anchor-lang = { version = "0.29.0", optional = true }
 num-traits = "0.2.17"
 typenum = { version = "1.17.0", features = ["i128"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ categories = ["data-structures"]
 travis-ci = { repository = "programble/fix" }
 
 [features]
-i128 = ["typenum/i128"]
+borsh = [ "dep:borsh" ]
 
 [dependencies]
-anchor-lang = "0.29.0"
-borsh = { version = "1.3.1", features = ["derive", "std"] }
+borsh = { version = "1.3.1", features = ["derive", "std"], optional = true }
 num-traits = "0.2.17"
 typenum = { version = "1.17.0", features = ["i128"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["0xPlish <plish@hylo.so>", "Curtis McEnroe <programble@gmail.com>"]
 repository = "https://github.com/hylo-so/fix"
 license = "ISC"
 readme = "README.md"
-keywords = ["math", "fixed", "point", "fixpoint", "basis", "number", "integer", "arithmetic", "solana"]
+keywords = ["math", "fixed", "fixpoint", "anchor", "solana"]
 categories = ["data-structures"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ travis-ci = { repository = "programble/fix" }
 i128 = ["typenum/i128"]
 
 [dependencies]
+borsh = { version = "1.3.1", features = ["derive"] }
 num-traits = "0.2.17"
 typenum = "1.17.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ use typenum::type_operators::{Abs, IsLess};
 /// - _(x B<sup>E</sup>) % y = (x % y) B<sup>E</sup>_
 #[cfg_attr(
     feature = "anchor",
-    derive(anchor::prelude::AnchorSerialize, anchor::prelude::AnchorDeserialize)
+    derive(anchor_lang::prelude::AnchorSerialize, anchor_lang::prelude::AnchorDeserialize)
 )]
 pub struct Fix<Bits, Base, Exp> {
     /// The underlying integer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use core::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use anchor_lang::prelude::{AnchorSerialize, AnchorDeserialize, borsh};
 use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use typenum::consts::Z0;
 use typenum::marker_traits::{Bit, Integer, Unsigned};
@@ -116,7 +116,7 @@ use typenum::type_operators::{Abs, IsLess};
 /// - _(x B<sup>E</sup>) × y = (x × y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) ÷ y = (x ÷ y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) % y = (x % y) B<sup>E</sup>_
-#[derive(BorshDeserialize, BorshSerialize)]
+#[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct Fix<Bits, Base, Exp> {
     /// The underlying integer.
     pub bits: Bits,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use core::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 
+#[cfg_attr(feature = "anchor", allow(unused_imports))]
+use anchor_lang::prelude::{borsh, AnchorDeserialize, AnchorSerialize};
 use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use typenum::consts::Z0;
 use typenum::marker_traits::{Bit, Integer, Unsigned};
@@ -110,14 +112,7 @@ use typenum::type_operators::{Abs, IsLess};
 /// - _(x B<sup>E</sup>) × y = (x × y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) ÷ y = (x ÷ y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) % y = (x % y) B<sup>E</sup>_
-#[cfg_attr(
-    feature = "anchor",
-    derive(
-        anchor_lang::prelude::AnchorSerialize,
-        anchor_lang::prelude::AnchorDeserialize,
-        anchor_lang::prelude::borsh
-    )
-)]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct Fix<Bits, Base, Exp> {
     /// The underlying integer.
     pub bits: Bits,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use core::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 
-#[cfg_attr(feature = "anchor", allow(unused_imports))]
+#[cfg(feature = "anchor")]
 use anchor_lang::prelude::{borsh, AnchorDeserialize, AnchorSerialize};
 use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use typenum::consts::Z0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,12 @@ impl Pow for u64 {
         self.pow(exp)
     }
 }
+impl Pow for u128 {
+    #[inline]
+    fn pow(self, exp: u32) -> Self {
+        self.pow(exp)
+    }
+}
 impl Pow for usize {
     #[inline]
     fn pow(self, exp: u32) -> Self {
@@ -333,6 +339,12 @@ impl Pow for i64 {
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
+}
+impl Pow for i128 {
+  #[inline]
+  fn pow(self, exp: u32) -> Self {
+    self.pow(exp)
+  }
 }
 impl Pow for isize {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,8 @@
 //! # `no_std`
 //!
 //! This crate is `no_std`.
-//!
-//! # `i128` support
-//!
-//! Support for `u128` and `i128` can be enabled on nightly Rust through the `i128` Cargo feature.
 
 #![no_std]
-#![cfg_attr(feature = "i128", feature(i128_type))]
 
 pub extern crate num_traits;
 pub extern crate typenum;
@@ -285,30 +280,35 @@ impl Pow for u8 {
         self.pow(exp)
     }
 }
+
 impl Pow for u16 {
     #[inline]
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
 }
+
 impl Pow for u32 {
     #[inline]
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
 }
+
 impl Pow for u64 {
     #[inline]
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
 }
+
 impl Pow for u128 {
     #[inline]
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
 }
+
 impl Pow for usize {
     #[inline]
     fn pow(self, exp: u32) -> Self {
@@ -322,61 +322,39 @@ impl Pow for i8 {
         self.pow(exp)
     }
 }
+
 impl Pow for i16 {
     #[inline]
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
 }
+
 impl Pow for i32 {
     #[inline]
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
 }
+
 impl Pow for i64 {
     #[inline]
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
 }
+
 impl Pow for i128 {
-  #[inline]
-  fn pow(self, exp: u32) -> Self {
-    self.pow(exp)
-  }
-}
-impl Pow for isize {
     #[inline]
     fn pow(self, exp: u32) -> Self {
         self.pow(exp)
     }
 }
 
-#[cfg(feature = "i128")]
-mod __i128 {
-    use super::*;
-    impl FromUnsigned for u128 {
-        fn from_unsigned<U: Unsigned>() -> Self {
-            U::to_u128()
-        }
-    }
-    impl FromUnsigned for i128 {
-        fn from_unsigned<U: Unsigned>() -> Self {
-            U::to_i128()
-        }
-    }
-    impl Pow for u128 {
-        #[inline]
-        fn pow(self, exp: u32) -> Self {
-            self.pow(exp)
-        }
-    }
-    impl Pow for i128 {
-        #[inline]
-        fn pow(self, exp: u32) -> Self {
-            self.pow(exp)
-        }
+impl Pow for isize {
+    #[inline]
+    fn pow(self, exp: u32) -> Self {
+        self.pow(exp)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,8 @@ use typenum::type_operators::{Abs, IsLess};
 /// - _(x B<sup>E</sup>) ÷ y = (x ÷ y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) % y = (x % y) B<sup>E</sup>_
 #[cfg_attr(
-    feature = "borsh",
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+    feature = "anchor",
+    derive(AnchorSerialize, AnchorDeserialize)
 )]
 pub struct Fix<Bits, Base, Exp> {
     /// The underlying integer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,9 @@
 //! Support for `u128` and `i128` can be enabled on nightly Rust through the `i128` Cargo feature.
 
 #![no_std]
-
 #![cfg_attr(feature = "i128", feature(i128_type))]
 
+pub extern crate num_traits;
 pub extern crate typenum;
 
 /// Type aliases.
@@ -82,12 +82,12 @@ use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use core::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 
+use borsh::{BorshDeserialize, BorshSerialize};
+use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use typenum::consts::Z0;
 use typenum::marker_traits::{Bit, Integer, Unsigned};
 use typenum::operator_aliases::{AbsVal, Diff, Le, Sum};
 use typenum::type_operators::{Abs, IsLess};
-
-use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 
 /// Fixed-point number representing _Bits × Base <sup>Exp</sup>_.
 ///
@@ -116,6 +116,7 @@ use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 /// - _(x B<sup>E</sup>) × y = (x × y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) ÷ y = (x ÷ y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) % y = (x % y) B<sup>E</sup>_
+#[derive(BorshDeserialize, BorshSerialize)]
 pub struct Fix<Bits, Base, Exp> {
     /// The underlying integer.
     pub bits: Bits,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ use typenum::type_operators::{Abs, IsLess};
 /// - _(x B<sup>E</sup>) % y = (x % y) B<sup>E</sup>_
 #[cfg_attr(
     feature = "anchor",
-    derive(AnchorSerialize, AnchorDeserialize)
+    derive(anchor::prelude::AnchorSerialize, anchor::prelude::AnchorDeserialize)
 )]
 pub struct Fix<Bits, Base, Exp> {
     /// The underlying integer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@ use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use core::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 
-use anchor_lang::prelude::{borsh, AnchorDeserialize, AnchorSerialize};
 use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use typenum::consts::Z0;
 use typenum::marker_traits::{Bit, Integer, Unsigned};
@@ -111,7 +110,10 @@ use typenum::type_operators::{Abs, IsLess};
 /// - _(x B<sup>E</sup>) × y = (x × y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) ÷ y = (x ÷ y) B<sup>E</sup>_
 /// - _(x B<sup>E</sup>) % y = (x % y) B<sup>E</sup>_
-#[derive(AnchorSerialize, AnchorDeserialize)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 pub struct Fix<Bits, Base, Exp> {
     /// The underlying integer.
     pub bits: Bits,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,11 @@ use typenum::type_operators::{Abs, IsLess};
 /// - _(x B<sup>E</sup>) % y = (x % y) B<sup>E</sup>_
 #[cfg_attr(
     feature = "anchor",
-    derive(anchor_lang::prelude::AnchorSerialize, anchor_lang::prelude::AnchorDeserialize)
+    derive(
+        anchor_lang::prelude::AnchorSerialize,
+        anchor_lang::prelude::AnchorDeserialize,
+        anchor_lang::prelude::borsh
+    )
 )]
 pub struct Fix<Bits, Base, Exp> {
     /// The underlying integer.


### PR DESCRIPTION
- Try adding Borsh derivations
- Add Anchor
- Add i128 support and map_bits
- Add Pow instance for u128
- Make i128 a default feature
- Remove anchor feature and gate derivation
- Use anchor instead of borsh to derive traits
- Qualify anchor derives
- Fix anchor import
- Add borsh derive
- Add prelude import
