### PR TITLE
TryFrom for FixValue variants into Fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "fix"
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
-anchor-lang = "0.30"
+anchor-lang = "0.30.1"
 anyhow = "1.0.82"
 muldiv = "1.0.1"
 num-traits = "0.2.17"

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
             openssl
             pkg-config
             rust-bin.stable.latest.complete  
+            rust-analyzer
           ];
         };
       };


### PR DESCRIPTION
Previously the library would unsafely allow conversion from e.g. UFixValue64
straight to UFix64 without checking the exponent. It has been modified to use a
TryFrom instance instead of a pure From.
